### PR TITLE
Link to C# PortableText converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Examples of custom blocks:
 #### C#
 
 - The `SanityHtmlBuilder` class in [the Sanity LINQ client](https://github.com/oslofjord/sanity-linq)
-- [PortableText](https://github.com/nhi/NHI.PortableText.DotNet), a NuGet package to convert HTML to Portable Text, also supporting custom types. (A graceful port of [`blockTools.htmlToBlocks()`](https://www.npmjs.com/package/@sanity/block-tools#htmltoblockshtml-blockcontenttype-options-html-deserializer) to C#)
+- [Portable Text .NET](https://github.com/nhi/portable-text-dotnet), a C# HTML converter to Portable Text, also supporting custom types. (A graceful port of [`blockTools.htmlToBlocks()`](https://www.npmjs.com/package/@sanity/block-tools#htmltoblockshtml-blockcontenttype-options-html-deserializer) to C#)
 ---
 
 Portable Text is presented by [Sanity.io](https://github.com/sanity-io)

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Examples of custom blocks:
 #### C#
 
 - The `SanityHtmlBuilder` class in [the Sanity LINQ client](https://github.com/oslofjord/sanity-linq)
-
+- [PortableText](https://github.com/nhi/NHI.PortableText.DotNet), a NuGet package to convert HTML to Portable Text, also supporting custom types. (A graceful port of [`blockTools.htmlToBlocks()`](https://www.npmjs.com/package/@sanity/block-tools#htmltoblockshtml-blockcontenttype-options-html-deserializer) to C#)
 ---
 
 Portable Text is presented by [Sanity.io](https://github.com/sanity-io)


### PR DESCRIPTION
We at https://nhi.no are proud to announce an HTML to PortableText converter written in C# :tada:!

For those who use .NET backend and HTML in their CMS, this can be a nice package to migrate over to sanity or keep operating with a CMS that can only produce HTML but you wish to use a modern frontend framework/library, like React.

**It is customizable, and supports adding custom parsers, to create your own data types!**

:eyes: Try it out in the online editor: https://portabletext-frontend-nhi.azurewebsites.net/
:package: Or get the package from NuGet here: https://www.nuget.org/packages/NHI.PortableText/
Source code/docs :books:: https://github.com/nhi/NHI.PortableText.DotNet

:exclamation: Keep in mind, this is an initial release, and we would like some feedback, both from Sanity (cc: @kmelve) on the compliance to the spec, and others on the ease of use.

We welcome PRs and issues in the repository, in fact, there are some beginner-friendly initial issues for those who would like to contribute.

PS: If you know any businesses using C# that wish to try PortableText, please give them a heads-up! We would like to spread that this now exists, and encourage others to contribute/create their own parsers in other languages! We think that PortableText is an amazing format, that should not be limited to JavaScript only. :heart:

Have a nice day! :wave: