### PR TITLE
clarify mark decorator/annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The text contents of the span.
 
 ### Custom blocks
 
-Custom blocks is typically images, code blocks, tables, video embeds, or any data structure. Custom blocks should be given a `_type`.
+Custom blocks is typically images (for inline images, see the marks section), code blocks, tables, video embeds, or any data structure. Custom blocks should be given a `_type`.
 
 Examples of custom blocks:
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ All children must be typed. The type makes it possible for a serializer to parse
 
 #### marks (array)
 
-An array of decorators or keys that corresponds with those in the block mark definitions (markDefs). A decorator is a string that describes some arbitrary feature of the span:
+Marks is how we mark up inline text with additional data/features. Marks comes in two forms: Decorators and Annotations. Decorators are marks as simple string values, while Annotations are keys to a data structure. `marks` is therefore either an array of string values, or keys, corresponding to `markDefs`, with the same `_key`. See the examples below, or check out this [live CodeSandbox example with an inline image and a link](https://codesandbox.io/s/awesome-sammet-71gy8?file=/src/App.js):
 
+Decorator example:
 ```json
 [
   {
@@ -126,6 +127,30 @@ An array of decorators or keys that corresponds with those in the block mark def
   }
 ]
 ```
+
+Annotation example:
+```js
+[
+  {
+    "_type": "block",
+    "children": [
+      {
+        "_type": "span",
+        "text": "Portable Text",
+        "marks": ["<markDefId>"] // this corresponds to a `"_key"` in `markDefs`
+      },
+    ],
+    "markDefs": [
+      {
+        "_type": "link",
+        "_key": "<markDefId>", // this corresponds to a value in `children.marks`
+        "href": "https://www.portabletext.org"
+      }
+    ]
+  }
+]
+```
+
 
 #### Text (string)
 


### PR DESCRIPTION
After building our own parser based on the spec, we had some problems with the spec not being totally clear here.

I clarified the description of marks, and added a live example (pointing to [CodeSandbox](https://codesandbox.io/s/awesome-sammet-71gy8?file=/src/App.js)) and an inline example for how to use decorator marks.


This is loosely connected to https://github.com/sanity-io/block-content-to-hyperscript/issues/21,

where we assumed that `marks` are acceptable on custom block types, but [caused problems](https://codesandbox.io/s/young-platform-8kz1i?fontsize=14&hidenavigation=1&theme=light&file=/src/App.js:470-489) with the `@sanity/block-content-to-react` renderer.

Because the spec says that images are usually implemented with custom block types, but we needed to wrap images in links. It makes sense now that those images have to be inline, and with the proper use of marks we can achieve [what we wanted](https://codesandbox.io/s/awesome-sammet-71gy8?file=/src/App.js).