### PR TITLE
Add Python HTML renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Examples of custom blocks:
 
 #### Python
 
-- [sanity-html](https://github.com/otovo/python-sanity-html)
+- [portabletext-html](https://github.com/otovo/python-portabletext-html)
 
 #### C#
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ Examples of custom blocks:
 
 - The `Sanity\BlockContent` class in [the sanity-php client](https://github.com/sanity-io/sanity-php)
 
+#### Python
+
+- [sanity-html](https://github.com/otovo/python-sanity-html)
+
 #### C#
 
 - The `SanityHtmlBuilder` class in [the Sanity LINQ client](https://github.com/oslofjord/sanity-linq)


### PR DESCRIPTION
Hello 👋

This is a bit of a tentative PR, to share the Portable Text HTML renderer we've written for Python: https://github.com/otovo/python-sanity-html

The package should be fully functional, with the exception of not yet having built-in support for the `image` type (which is something we intend to add when we get time). Once that's added we plan to bump the package version to v0.1 and then probably to v1 shortly after.

Not sure if you would prefer to hold off on merging this until it's at v1 or not; just wanted to open this in case it might benefit others in the meantime - since we're not aware of any other Python parsers out there 🙂 