### PR TITLE
docs: add link to astro-portabletext

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Examples of custom blocks:
 - [@sanity/block-tools](https://www.npmjs.com/package/%40sanity/block-tools)
 - [@sanity/block-content-to-hyperscript](https://www.npmjs.com/package/%40sanity/block-content-to-hyperscript)
 - [@sanity/block-content-to-markdown](https://www.npmjs.com/package/%40sanity/block-content-to-markdown)
+- [theisel/astro-portabletext](https://github.com/theisel/astro-portabletext)
 
 #### PHP
 


### PR DESCRIPTION
I expect some people will come looking for an Astro library, and we already recommend and use this one ourselves.